### PR TITLE
デプロイで起こるエラーの解決

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -10,8 +10,8 @@ CarrierWave.configure do |config|
     config.fog_provider = 'fog/aws'
     config.fog_credentials = {
       provider: 'AWS',
-      aws_access_key_id: ENV[:access_key_id],
-      aws_secret_access_key: ENV[:secret_access_key],
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       region: 'ap-northeast-1'
     }
     config.fog_directory  = 'flea-market-72c'


### PR DESCRIPTION
# What
TypeError: no implicit conversion of Symbol into Stringを解決
# Why
文字列ではなくシンボル型になっていて、デプロイでエラーが出たので修正する必要があった。