### PR TITLE
商品をキーワード検索できる機能をつける

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,4 @@ gem "devise"
 gem "rspec-rails"
 gem "factory_bot_rails"
 gem "payjp"
+gem 'kaminari'

--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,4 @@ gem "rspec-rails"
 gem "factory_bot_rails"
 gem "payjp"
 gem 'kaminari'
+gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.4.3)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -390,6 +394,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-controller-testing
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,18 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     kgio (2.11.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -369,6 +381,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/assets/stylesheets/modules/items/search.scss
+++ b/app/assets/stylesheets/modules/items/search.scss
@@ -1,0 +1,65 @@
+.items-result{
+  background-color: $backGroundGray;
+  padding: 60px 0;
+  &__title{
+    @include bold();
+    text-align: center;
+    font-size: 28px;
+  }
+  &__contents{
+    width: 100%;
+    .headline{
+      @include bold();
+      color: $mainBlue;
+      font-size: 24px;
+      text-align: center;
+      padding-top: 10px;
+    }
+    .items{
+      @include displayFlex();
+      flex-wrap: wrap;
+      padding: 30px 30px;
+      &--text-decoration_none{
+        @include blackLink();
+        padding: 20px;
+      }
+      &__item{
+        @include hoverWhiteFilter();
+        background-color: white;
+        border: solid 1px rgba(211, 211, 211, 0.616);
+        .image{
+          width: 220px;
+          height:150px;
+          border-bottom: solid 1px rgba(194, 188, 188, 0.719);
+        }
+        .detail{
+          padding: 16px;
+          &__name{
+            font-size: 16px;
+          }
+          &__info{
+            @include displayFlex();
+            justify-content: space-between;
+            .favorate{
+              width: 10px;
+            }
+          }
+          &__tax{
+            font-size: 10px;
+          }
+        }
+
+      }
+    }
+    .pagination{
+      text-align: center;
+ 
+      a{
+        color: $mainBlue();
+        
+      }
+    }
+
+  }
+
+}

--- a/app/assets/stylesheets/modules/partials/header.scss
+++ b/app/assets/stylesheets/modules/partials/header.scss
@@ -21,13 +21,13 @@
         @include hoverMouseFinger();
         background-color: $mainBlue;
         width: 36px;
-        height: 35px;
+        height: 33px;
         border: none;
       }
       &__image {
         @include hoverMouseFinger();
         position: absolute;
-        right: 10px;
+        right: 13px;
         top: 7px;
       }
     }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,6 +37,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def search
+    @items = Item.search(params[:keyword]).order("created_at DESC").page(params[:page]).per(30)
+  end
+
   #モデルから子カテゴリー取得
   def category_children
     @category_children = Category.find(params[:parent_name]).children

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,4 +24,12 @@ class Item < ApplicationRecord
   #-- 複数の画像を登録するための記述
   accepts_nested_attributes_for :images
 
+  def self.search(search)
+    if search
+      Item.where('name LIKE(?)', "%#{search}%")
+    else
+      Item.all
+    end
+  end
+
 end

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -4,10 +4,12 @@
       = link_to root_path do
         = image_tag "/logo.png", size: "140x40"
     .search
-      %input.search__input{placeholder: " キーワードから探す"}
-      %label
-        %input.search__submit{type: "submit", value: ""}
-        = image_tag "/search_btn.png", size: "21x21", class: "search__image"
+      = form_with(url: search_items_path, local: true, method: :get, class: "search") do |f|
+        = f.search_field :keyword, placeholder: "キーワードから探す", class: "search__input"
+        %label
+          = f.submit "" , class: "search__submit"
+          = image_tag "/search_btn.png", size: "21x21", class: "search__image"
+
   .header__downside
     .left
       .left__category

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -127,9 +127,6 @@
                   = item.price
                   %span<>
                   円
-                .favorite
-                  = icon("fas", "star")
-                  0
               .detail__tax
                 (税込)
 - if user_signed_in?

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -1,0 +1,32 @@
+= render partial: "header"
+.items-result
+  .items-result__title
+    商品一覧
+  .items-result__contents
+    .headline
+      商品の検索結果一覧
+    .items
+      - @items.each do |item|
+        = link_to item_path(item.id), class: "items--text-decoration_none" do
+          .items__item
+            .image
+              = image_tag item.images[0].src.url, size: "220x150"
+            .detail
+              .detail__name
+                = item.name
+              .detail__info
+                .price
+                  = item.price
+                  %span<>
+                  円
+                .favorite
+                  = icon("fas", "star")
+                  0
+              .detail__tax
+                (税込)
+    = paginate(@items)
+- if user_signed_in?
+  = render partial: "footer"
+  = render partial: "items/post-btn"
+- else
+  = render partial: "footer"

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -22,8 +22,8 @@
               .detail__tax
                 (税込)
     = paginate(@items)
-- if user_signed_in?
   = render partial: "footer"
+- if user_signed_in?
   = render partial: "items/post-btn"
 - else
-  = render partial: "footer"
+  = render partial: ""

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -19,9 +19,6 @@
                   = item.price
                   %span<>
                   円
-                .favorite
-                  = icon("fas", "star")
-                  0
               .detail__tax
                 (税込)
     = paginate(@items)

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -25,5 +25,3 @@
   = render partial: "footer"
 - if user_signed_in?
   = render partial: "items/post-btn"
-- else
-  = render partial: ""

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,10 +26,11 @@ Rails.application.routes.draw do
       post 'pay'
     end
   end
-  resources :items, only: [:show, :new, :create, :destroy] do
+  resources :items, only: [:show, :new, :create, :destroy, :search] do
     collection do
       get 'category_children', to: 'items#category_children', defaults: { format: 'json' }
       get 'category_grandchildren', to: 'items#category_grandchildren', defaults: { format: 'json' }
+      get 'search'
     end
   end
   resources :buyers, only: :index

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe ItemsController do
+  describe 'GET #search' do
+    it "@itemsは期待した値になること？" do
+      @items = [create(:item)]
+      get :search, params: { name: @items[0] }
+      expect(assigns(:items)).to eq @items 
+    end
+
+    it "search.html.hamlに遷移すること" do
+      get :search
+      expect(response).to render_template :search
+    end
+  end
+end

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :category do
+    name        {"レディース"}
+    ancestry    {"1"}
+    
+  end
+end
+
+
+

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
     start_address    {"沖縄"}
     shipping_date    {"4~7で発送"}
     price            {"3000"}
+    user
+    category
   end
 
 end


### PR DESCRIPTION
# What
トップページの上部から、商品をキーワード検索することができるようにする
# Why
出品商品を瞬時に検索できるようにすることで利便性を高めるため。
商品検索
https://gyazo.com/90036040f163758459a9e7111f256e18
単体テスト
https://gyazo.com/1d9a4b2d516a37c3ae21f457278f93e3