### PR TITLE
商品検索時に売却済商品は対象外とする

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -61,7 +61,7 @@ class ItemsController < ApplicationController
   end
 
   def search
-    @items = Item.search(params[:keyword]).order("created_at DESC").page(params[:page]).per(30)
+    @items = Item.search(params[:keyword]).where(trading_status: "出品中").order("created_at DESC").page(params[:page]).per(30)
   end
 
   #モデルから子カテゴリー取得

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -32,5 +32,4 @@ class Item < ApplicationRecord
       Item.all
     end
   end
-
 end


### PR DESCRIPTION
# What
商品検索時に売却済みの商品は検索できないようにする。
# Why
フリマアプリにおいて売却済の商品を検索できても意味がないから。